### PR TITLE
feat(categories): service-layer attach/detach + reads include categories

### DIFF
--- a/src/lib/services/create-activity-from-template.ts
+++ b/src/lib/services/create-activity-from-template.ts
@@ -32,10 +32,13 @@ export async function createActivityFromTemplate({
             where: { deletedAt: null },
             orderBy: { position: "asc" },
           },
+          categories: {
+            select: { categoryId: true },
+          },
         },
       });
 
-      return await tx.activity.create({
+      const created = await tx.activity.create({
         data: {
           name: sourceActivity.name,
           description: sourceActivity.description
@@ -52,6 +55,18 @@ export async function createActivityFromTemplate({
           },
         },
       });
+
+      if (sourceActivity.categories.length > 0) {
+        await tx.activityCategory.createMany({
+          data: sourceActivity.categories.map(({ categoryId }) => ({
+            activityId: created.id,
+            categoryId,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      return created;
     });
   } catch (error) {
     console.error("Error creating activity from template:", error);

--- a/src/lib/services/create-activity-from-template.ts
+++ b/src/lib/services/create-activity-from-template.ts
@@ -38,12 +38,10 @@ export async function createActivityFromTemplate({
         },
       });
 
-      const created = await tx.activity.create({
+      return tx.activity.create({
         data: {
           name: sourceActivity.name,
-          description: sourceActivity.description
-            ? sourceActivity.description
-            : null,
+          description: sourceActivity.description ?? null,
           teamId: sourceActivity.teamId,
           userId: userId,
           tasks: {
@@ -53,20 +51,16 @@ export async function createActivityFromTemplate({
               durationMs: task.durationMs,
             })),
           },
+          categories: {
+            createMany: {
+              data: sourceActivity.categories.map(({ categoryId }) => ({
+                categoryId,
+              })),
+              skipDuplicates: true,
+            },
+          },
         },
       });
-
-      if (sourceActivity.categories.length > 0) {
-        await tx.activityCategory.createMany({
-          data: sourceActivity.categories.map(({ categoryId }) => ({
-            activityId: created.id,
-            categoryId,
-          })),
-          skipDuplicates: true,
-        });
-      }
-
-      return created;
     });
   } catch (error) {
     console.error("Error creating activity from template:", error);

--- a/src/lib/services/create-activity.ts
+++ b/src/lib/services/create-activity.ts
@@ -1,4 +1,4 @@
-import type { Activity } from "@prisma/client";
+import type { ActivityWithCategories } from "@/types";
 import { TeamMembershipRole } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
@@ -6,13 +6,15 @@ type CreateActivityParams = {
   name: string;
   description: string;
   userId: string;
+  categoryIds?: string[];
 };
 
 export async function createActivity({
   name,
   description,
   userId,
-}: CreateActivityParams): Promise<Activity> {
+  categoryIds,
+}: CreateActivityParams): Promise<ActivityWithCategories> {
   try {
     return await prisma.$transaction(async (tx) => {
       const teamMembership = await tx.teamMembership.findFirstOrThrow({
@@ -20,14 +22,50 @@ export async function createActivity({
         select: { teamId: true },
       });
 
-      return tx.activity.create({
+      const activity = await tx.activity.create({
         data: {
           name,
           description,
           teamId: teamMembership.teamId,
           userId,
         },
+        include: {
+          categories: {
+            include: {
+              category: true,
+            },
+          },
+        },
       });
+
+      if (categoryIds && categoryIds.length > 0) {
+        const uniqueIds = Array.from(new Set(categoryIds));
+        const count = await tx.category.count({
+          where: { id: { in: uniqueIds }, teamId: teamMembership.teamId },
+        });
+        if (count !== uniqueIds.length) {
+          throw new Error("One or more categories do not belong to your team");
+        }
+        await tx.activityCategory.createMany({
+          data: uniqueIds.map((categoryId) => ({
+            activityId: activity.id,
+            categoryId,
+          })),
+          skipDuplicates: true,
+        });
+        return tx.activity.findFirstOrThrow({
+          where: { id: activity.id },
+          include: {
+            categories: {
+              include: {
+                category: true,
+              },
+            },
+          },
+        });
+      }
+
+      return activity;
     });
   } catch (error) {
     console.error("Error creating activity:", error);

--- a/src/lib/services/create-activity.ts
+++ b/src/lib/services/create-activity.ts
@@ -40,10 +40,11 @@ export async function createActivity({
 
       if (categoryIds && categoryIds.length > 0) {
         const uniqueIds = Array.from(new Set(categoryIds));
-        const count = await tx.category.count({
+        const ownedCategories = await tx.category.findMany({
           where: { id: { in: uniqueIds }, teamId: teamMembership.teamId },
+          select: { id: true },
         });
-        if (count !== uniqueIds.length) {
+        if (ownedCategories.length !== uniqueIds.length) {
           throw new Error("One or more categories do not belong to your team");
         }
         await tx.activityCategory.createMany({

--- a/src/lib/services/create-activity.ts
+++ b/src/lib/services/create-activity.ts
@@ -22,24 +22,9 @@ export async function createActivity({
         select: { teamId: true },
       });
 
-      const activity = await tx.activity.create({
-        data: {
-          name,
-          description,
-          teamId: teamMembership.teamId,
-          userId,
-        },
-        include: {
-          categories: {
-            include: {
-              category: true,
-            },
-          },
-        },
-      });
+      const uniqueIds = categoryIds ? Array.from(new Set(categoryIds)) : null;
 
-      if (categoryIds && categoryIds.length > 0) {
-        const uniqueIds = Array.from(new Set(categoryIds));
+      if (uniqueIds !== null) {
         const ownedCategories = await tx.category.findMany({
           where: { id: { in: uniqueIds }, teamId: teamMembership.teamId },
           select: { id: true },
@@ -47,26 +32,27 @@ export async function createActivity({
         if (ownedCategories.length !== uniqueIds.length) {
           throw new Error("One or more categories do not belong to your team");
         }
-        await tx.activityCategory.createMany({
-          data: uniqueIds.map((categoryId) => ({
-            activityId: activity.id,
-            categoryId,
-          })),
-          skipDuplicates: true,
-        });
-        return tx.activity.findFirstOrThrow({
-          where: { id: activity.id },
-          include: {
-            categories: {
-              include: {
-                category: true,
-              },
-            },
-          },
-        });
       }
 
-      return activity;
+      return tx.activity.create({
+        data: {
+          name,
+          description,
+          teamId: teamMembership.teamId,
+          userId,
+          ...(uniqueIds !== null && {
+            categories: {
+              createMany: {
+                data: uniqueIds.map((categoryId) => ({ categoryId })),
+                skipDuplicates: true,
+              },
+            },
+          }),
+        },
+        include: {
+          categories: { include: { category: true } },
+        },
+      });
     });
   } catch (error) {
     console.error("Error creating activity:", error);

--- a/src/lib/services/get-activities.ts
+++ b/src/lib/services/get-activities.ts
@@ -83,6 +83,11 @@ export async function getActivities({
             position: "asc",
           },
         },
+        categories: {
+          include: {
+            category: true,
+          },
+        },
       },
       skip,
       take: limit,

--- a/src/lib/services/get-activity.ts
+++ b/src/lib/services/get-activity.ts
@@ -38,6 +38,11 @@ export async function getActivity({
             position: "asc",
           },
         },
+        categories: {
+          include: {
+            category: true,
+          },
+        },
       },
     });
   } catch (error) {

--- a/src/lib/services/get-bookmarked-activities.ts
+++ b/src/lib/services/get-bookmarked-activities.ts
@@ -38,6 +38,11 @@ export async function getBookmarkedActivities({
           position: "asc",
         },
       },
+      categories: {
+        include: {
+          category: true,
+        },
+      },
     },
   });
 

--- a/src/lib/services/update-activity.ts
+++ b/src/lib/services/update-activity.ts
@@ -1,4 +1,4 @@
-import type { Activity } from "@prisma/client";
+import type { ActivityWithCategories } from "@/types";
 import { TeamMembershipRole } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 
@@ -7,6 +7,7 @@ type UpdateActivityParams = {
   name?: string;
   description?: string;
   userId: string;
+  categoryIds?: string[];
 };
 
 export async function updateActivity({
@@ -14,12 +15,11 @@ export async function updateActivity({
   name,
   description,
   userId,
-}: UpdateActivityParams): Promise<Activity> {
+  categoryIds,
+}: UpdateActivityParams): Promise<ActivityWithCategories> {
   try {
     return await prisma.$transaction(async (tx) => {
-      // Find the activity and ensure the user is the owner
-      // of the team
-      await tx.activity.findFirstOrThrow({
+      const activity = await tx.activity.findFirstOrThrow({
         where: {
           id: activityId,
           userId,
@@ -35,11 +35,42 @@ export async function updateActivity({
         },
       });
 
+      if (categoryIds !== undefined) {
+        await tx.activityCategory.deleteMany({
+          where: { activityId },
+        });
+        if (categoryIds.length > 0) {
+          const uniqueIds = Array.from(new Set(categoryIds));
+          const count = await tx.category.count({
+            where: { id: { in: uniqueIds }, teamId: activity.teamId },
+          });
+          if (count !== uniqueIds.length) {
+            throw new Error(
+              "One or more categories do not belong to your team"
+            );
+          }
+          await tx.activityCategory.createMany({
+            data: uniqueIds.map((categoryId) => ({
+              activityId,
+              categoryId,
+            })),
+            skipDuplicates: true,
+          });
+        }
+      }
+
       return tx.activity.update({
         where: { id: activityId },
         data: {
           ...(name && { name }),
           ...(description !== undefined && { description }),
+        },
+        include: {
+          categories: {
+            include: {
+              category: true,
+            },
+          },
         },
       });
     });

--- a/src/lib/services/update-activity.ts
+++ b/src/lib/services/update-activity.ts
@@ -35,28 +35,17 @@ export async function updateActivity({
         },
       });
 
-      if (categoryIds !== undefined) {
-        await tx.activityCategory.deleteMany({
-          where: { activityId },
+      const uniqueIds = categoryIds !== undefined ? Array.from(new Set(categoryIds)) : null;
+
+      if (uniqueIds !== null) {
+        const ownedCategories = await tx.category.findMany({
+          where: { id: { in: uniqueIds }, teamId: activity.teamId },
+          select: { id: true },
         });
-        if (categoryIds.length > 0) {
-          const uniqueIds = Array.from(new Set(categoryIds));
-          const ownedCategories = await tx.category.findMany({
-            where: { id: { in: uniqueIds }, teamId: activity.teamId },
-            select: { id: true },
-          });
-          if (ownedCategories.length !== uniqueIds.length) {
-            throw new Error(
-              "One or more categories do not belong to your team"
-            );
-          }
-          await tx.activityCategory.createMany({
-            data: uniqueIds.map((categoryId) => ({
-              activityId,
-              categoryId,
-            })),
-            skipDuplicates: true,
-          });
+        if (ownedCategories.length !== uniqueIds.length) {
+          throw new Error(
+            "One or more categories do not belong to your team"
+          );
         }
       }
 
@@ -65,13 +54,18 @@ export async function updateActivity({
         data: {
           ...(name && { name }),
           ...(description !== undefined && { description }),
+          ...(uniqueIds !== null && {
+            categories: {
+              deleteMany: {},
+              createMany: {
+                data: uniqueIds.map((categoryId) => ({ categoryId })),
+                skipDuplicates: true,
+              },
+            },
+          }),
         },
         include: {
-          categories: {
-            include: {
-              category: true,
-            },
-          },
+          categories: { include: { category: true } },
         },
       });
     });

--- a/src/lib/services/update-activity.ts
+++ b/src/lib/services/update-activity.ts
@@ -41,10 +41,11 @@ export async function updateActivity({
         });
         if (categoryIds.length > 0) {
           const uniqueIds = Array.from(new Set(categoryIds));
-          const count = await tx.category.count({
+          const ownedCategories = await tx.category.findMany({
             where: { id: { in: uniqueIds }, teamId: activity.teamId },
+            select: { id: true },
           });
-          if (count !== uniqueIds.length) {
+          if (ownedCategories.length !== uniqueIds.length) {
             throw new Error(
               "One or more categories do not belong to your team"
             );

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,21 @@ export type ActivityWithTasksAndTimeEntries = Prisma.ActivityGetPayload<{
         timeEntries: true;
       };
     };
+    categories: {
+      include: {
+        category: true;
+      };
+    };
+  };
+}>;
+
+export type ActivityWithCategories = Prisma.ActivityGetPayload<{
+  include: {
+    categories: {
+      include: {
+        category: true;
+      };
+    };
   };
 }>;
 


### PR DESCRIPTION
Closes #404

- createActivity / updateActivity: accept optional categoryIds, write join rows in-transaction with team-scope ownership check and dedupe; return new ActivityWithCategories.
- createActivityFromTemplate: clone source categories into the new activity. Return shape unchanged.
- getActivity / getActivities / getBookmarkedActivities: include categories as sibling of tasks. getActivities tasks filter preserved.
- Extend ActivityWithTasksAndTimeEntries to include categories so existing list/get callers receive them transparently.