### PR TITLE
feat(categories): wire CategoryPicker into upsert form + prefetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "lucide-react": "^1.14.0",
         "next": "16.2.4",
         "next-auth": "^5.0.0-beta.31",
-        "next-themes": "^0.4.6",
         "pg": "^8.20.0",
         "react": "^19.2.3",
         "react-circular-progressbar": "^2.2.0",
@@ -7444,14 +7443,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lucide-react": "^1.14.0",
     "next": "16.2.4",
     "next-auth": "^5.0.0-beta.31",
-    "next-themes": "^0.4.6",
     "pg": "^8.20.0",
     "react": "^19.2.3",
     "react-circular-progressbar": "^2.2.0",

--- a/src/app/dashboard/activities/[id]/components/activity-header.tsx
+++ b/src/app/dashboard/activities/[id]/components/activity-header.tsx
@@ -6,13 +6,14 @@ import { useSearchParams } from "next/navigation";
 import { ActivityIcon, ChevronLeft } from "lucide-react";
 import { ActivityActions } from "@/app/dashboard/components/activity-actions";
 import { BookmarkButton } from "@/components/bookmark-button";
-import type { ActivityWithTasksAndTimeEntries } from "@/types";
+import type { ActivityWithTasksAndTimeEntries, CategoryOption } from "@/types";
 
 type ActivityHeaderProps = {
   activity: ActivityWithTasksAndTimeEntries;
+  categories: CategoryOption[];
 };
 
-export function ActivityHeader({ activity }: ActivityHeaderProps) {
+export function ActivityHeader({ activity, categories }: ActivityHeaderProps) {
   const searchParams = useSearchParams();
   const returnUrl = searchParams.get("returnUrl") || "/dashboard";
 
@@ -45,7 +46,7 @@ export function ActivityHeader({ activity }: ActivityHeaderProps) {
           )}
         </div>
         <div className="flex items-center sm:self-center ml-auto sm:ml-0">
-          <ActivityActions activity={activity} redirectUrl={returnUrl} />
+          <ActivityActions activity={activity} redirectUrl={returnUrl} categories={categories} />
         </div>
       </div>
     </div>

--- a/src/app/dashboard/activities/[id]/page.tsx
+++ b/src/app/dashboard/activities/[id]/page.tsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { auth } from "@/lib/auth";
 import { notFound, redirect } from "next/navigation";
 import { getActivity } from "@/lib/services/get-activity";
+import { getCategories } from "@/lib/services/get-categories";
 import { TasksList } from "@/app/dashboard/activities/[id]/components/tasks-list";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ListTodoIcon, PlusCircleIcon } from "lucide-react";
@@ -32,7 +33,11 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     redirect("/auth/sign-in");
   }
 
-  const activity = await getActivity({ id: activityId, userId });
+  const [activity, rawCategories] = await Promise.all([
+    getActivity({ id: activityId, userId }),
+    getCategories({ userId }),
+  ]);
+  const categories = rawCategories.map(({ id, name }) => ({ id, name }));
 
   if (!activity) {
     notFound();
@@ -41,7 +46,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   return (
     <Suspense fallback={<ActivityPageSkeleton />}>
       <div className="container mx-auto space-y-8 h-full flex flex-col">
-        <ActivityHeader activity={activity} />
+        <ActivityHeader activity={activity} categories={categories} />
         {activity.completedAt ? (
           <div className="flex justify-center">
             <ActivityCompletedCard activity={activity} />

--- a/src/app/dashboard/activities/[id]/page.tsx
+++ b/src/app/dashboard/activities/[id]/page.tsx
@@ -33,11 +33,10 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     redirect("/auth/sign-in");
   }
 
-  const [activity, rawCategories] = await Promise.all([
+  const [activity, categories] = await Promise.all([
     getActivity({ id: activityId, userId }),
     getCategories({ userId }),
   ]);
-  const categories = rawCategories.map(({ id, name }) => ({ id, name }));
 
   if (!activity) {
     notFound();

--- a/src/app/dashboard/components/activities-list.tsx
+++ b/src/app/dashboard/components/activities-list.tsx
@@ -1,19 +1,20 @@
 import { ActivityCard } from "@/app/dashboard/components/activity-card";
 import { NoActivities } from "@/app/dashboard/components/no-activities";
-import type { ActivityWithTasksAndTimeEntries } from "@/types";
+import type { ActivityWithTasksAndTimeEntries, CategoryOption } from "@/types";
 
 type ActivitiesListProps = {
   activities: ActivityWithTasksAndTimeEntries[];
+  categories: CategoryOption[];
 };
 
-export function ActivitiesList({ activities }: ActivitiesListProps) {
+export function ActivitiesList({ activities, categories }: ActivitiesListProps) {
   if (activities.length === 0) return <NoActivities />;
 
   return (
     <ul className="space-y-4">
       {activities.map((activity) => (
         <li key={activity.id}>
-          <ActivityCard activity={activity} />
+          <ActivityCard activity={activity} categories={categories} />
         </li>
       ))}
     </ul>

--- a/src/app/dashboard/components/activities-section.tsx
+++ b/src/app/dashboard/components/activities-section.tsx
@@ -52,7 +52,7 @@ export async function ActivitiesSection({
       completionStatus,
     });
 
-  const categories = (await getCategories({ userId })).map(({ id, name }) => ({ id, name }));
+  const categories = await getCategories({ userId });
 
   const description = getActivityDescription({
     totalCount,

--- a/src/app/dashboard/components/activities-section.tsx
+++ b/src/app/dashboard/components/activities-section.tsx
@@ -1,4 +1,5 @@
 import { getActivities } from "@/lib/services/get-activities";
+import { getCategories } from "@/lib/services/get-categories";
 import { ActivityFilters } from "@/app/dashboard/components/activity-filters";
 import { ActivitiesList } from "@/app/dashboard/components/activities-list";
 import { Pagination } from "@/app/dashboard/components/pagination";
@@ -51,6 +52,8 @@ export async function ActivitiesSection({
       completionStatus,
     });
 
+  const categories = (await getCategories({ userId })).map(({ id, name }) => ({ id, name }));
+
   const description = getActivityDescription({
     totalCount,
     currentPage,
@@ -61,7 +64,7 @@ export async function ActivitiesSection({
     <>
       <p className="text-sm text-foreground mb-4">{description}</p>
       <ActivityFilters />
-      <ActivitiesList activities={activities} />
+      <ActivitiesList activities={activities} categories={categories} />
       <Pagination totalPages={totalPages} currentPage={currentPage} />
     </>
   );

--- a/src/app/dashboard/components/activity-actions.tsx
+++ b/src/app/dashboard/components/activity-actions.tsx
@@ -12,19 +12,21 @@ import {
 import { UpsertActivityDialog } from "@/components/upsert-activity-dialog";
 import { DeleteActivityDialog } from "@/components/delete-activity-dialog";
 import { BookmarkButton } from "@/components/bookmark-button";
-import type { ActivityWithTasksAndTimeEntries } from "@/types";
+import type { ActivityWithTasksAndTimeEntries, CategoryOption } from "@/types";
 import { useRouter } from "next/navigation";
 import { createActivityFromTemplateAction } from "@/app/actions/create-activity-from-template-action";
 import { useToast } from "@/hooks/use-toast";
 
 type ActivityActionsProps = {
   activity: ActivityWithTasksAndTimeEntries;
+  categories: CategoryOption[];
   redirectUrl?: string;
   returnUrl?: string;
 };
 
 export function ActivityActions({
   activity,
+  categories,
   redirectUrl,
   returnUrl,
 }: ActivityActionsProps) {
@@ -89,7 +91,7 @@ export function ActivityActions({
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-56" align="end" forceMount>
           <DropdownMenuItem asChild>
-            <UpsertActivityDialog activity={activity}>
+            <UpsertActivityDialog activity={activity} categories={categories}>
               <Button
                 variant="ghost"
                 className="w-full cursor-pointer justify-start"

--- a/src/app/dashboard/components/activity-card.tsx
+++ b/src/app/dashboard/components/activity-card.tsx
@@ -13,7 +13,7 @@ import {
 import { Calendar, CheckCircle } from "lucide-react";
 import { ActivityActions } from "@/app/dashboard/components/activity-actions";
 import { BookmarkButton } from "@/components/bookmark-button";
-import type { ActivityWithTasksAndTimeEntries } from "@/types";
+import type { ActivityWithTasksAndTimeEntries, CategoryOption } from "@/types";
 import {
   formatTimeHHMMss,
   formatDateAsTimeAgo,
@@ -30,12 +30,14 @@ import { useReturnUrl } from "@/hooks/use-return-url";
 
 type ActivityCardProps = {
   activity: ActivityWithTasksAndTimeEntries;
+  categories: CategoryOption[];
   showCompletedAt?: boolean;
   showDescription?: boolean;
 };
 
 export function ActivityCard({
   activity,
+  categories,
   showCompletedAt = true,
   showDescription = true,
 }: ActivityCardProps) {
@@ -66,7 +68,7 @@ export function ActivityCard({
                 {isRunning ? `(${formatTimeHHMMss(remainingTime)})` : null}
               </CardTitle>
             </div>
-            <ActivityActions activity={activity} returnUrl={returnUrl} />
+            <ActivityActions activity={activity} returnUrl={returnUrl} categories={categories} />
           </div>
           {showDescription && (
             <CardDescription className="text-sm text-muted-foreground mt-1 truncate min-h-[1.5rem]">

--- a/src/app/dashboard/components/bookmarked-activities-list.tsx
+++ b/src/app/dashboard/components/bookmarked-activities-list.tsx
@@ -1,4 +1,5 @@
 import { getBookmarkedActivities } from "@/lib/services/get-bookmarked-activities";
+import { getCategories } from "@/lib/services/get-categories";
 import { ActivityCard } from "@/app/dashboard/components/activity-card";
 import { NoBookmarkedActivities } from "@/app/dashboard/components/no-bookmarked-activities";
 
@@ -10,6 +11,7 @@ export async function BookmarkedActivitiesList({
   userId,
 }: BookmarkedActivitiesListProps) {
   const activities = await getBookmarkedActivities({ userId });
+  const categories = (await getCategories({ userId })).map(({ id, name }) => ({ id, name }));
 
   if (activities.length === 0) return <NoBookmarkedActivities />;
 
@@ -20,6 +22,7 @@ export async function BookmarkedActivitiesList({
           <ActivityCard
             activity={activity}
             key={activity.id}
+            categories={categories}
             showCompletedAt={false}
             showDescription={false}
           />

--- a/src/app/dashboard/components/bookmarked-activities-list.tsx
+++ b/src/app/dashboard/components/bookmarked-activities-list.tsx
@@ -11,7 +11,7 @@ export async function BookmarkedActivitiesList({
   userId,
 }: BookmarkedActivitiesListProps) {
   const activities = await getBookmarkedActivities({ userId });
-  const categories = (await getCategories({ userId })).map(({ id, name }) => ({ id, name }));
+  const categories = await getCategories({ userId });
 
   if (activities.length === 0) return <NoBookmarkedActivities />;
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -16,7 +16,7 @@ export default async function DashboardLayout({
 
   if (!session?.user?.id) redirect("/auth/sign-in");
   const userId = session.user.id;
-  const categories = (await getCategories({ userId })).map(({ id, name }) => ({ id, name }));
+  const categories = await getCategories({ userId });
 
   return (
     <SessionProvider session={session}>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,6 +3,8 @@ import { auth } from "@/lib/auth";
 import { SessionProvider } from "next-auth/react";
 import { NotificationManager } from "@/components/notification-manager";
 import { BottomNav } from "@/components/bottom-nav";
+import { redirect } from "next/navigation";
+import { getCategories } from "@/lib/services/get-categories";
 import type React from "react";
 
 export default async function DashboardLayout({
@@ -12,6 +14,10 @@ export default async function DashboardLayout({
 }>) {
   const session = await auth();
 
+  if (!session?.user?.id) redirect("/auth/sign-in");
+  const userId = session.user.id;
+  const categories = (await getCategories({ userId })).map(({ id, name }) => ({ id, name }));
+
   return (
     <SessionProvider session={session}>
       <NotificationManager />
@@ -20,7 +26,7 @@ export default async function DashboardLayout({
         <main className="flex-grow pt-6 mb-[82px]">
           <div className="container max-w-7xl mx-auto px-2">{children}</div>
         </main>
-        <BottomNav />
+        <BottomNav categories={categories} />
       </div>
     </SessionProvider>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import localFont from "next/font/local";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -23,22 +24,26 @@ export const metadata: Metadata = {
   description: "Small wins. Big progress.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = await cookies();
+  const themeCookie = cookieStore.get("theme")?.value;
+  const resolvedTheme = themeCookie === "dark" ? "dark" : "light";
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      className={resolvedTheme}
+      style={{ colorScheme: resolvedTheme }}
+      suppressHydrationWarning
+    >
       <body
         className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
       >
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
+        <ThemeProvider>
           <SetTimezoneCookie />
           <TooltipProvider>
             <div className="container max-w-7xl mx-auto px-2">{children}</div>

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -3,6 +3,7 @@
 import type React from "react";
 import Link from "next/link";
 import { Home, Plus, User } from "lucide-react";
+import type { CategoryOption } from "@/types";
 import { UserDropdownMenu } from "@/components/user-dropdown-menu";
 import { UpsertActivityDialog } from "@/components/upsert-activity-dialog";
 
@@ -40,7 +41,11 @@ function NavButton({
   );
 }
 
-export function BottomNav() {
+type BottomNavProps = {
+  categories: CategoryOption[];
+};
+
+export function BottomNav({ categories }: BottomNavProps) {
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-border">
       <nav className="container max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -51,7 +56,7 @@ export function BottomNav() {
             as={Link}
             href="/dashboard"
           />
-          <UpsertActivityDialog>
+          <UpsertActivityDialog categories={categories}>
             <NavButton icon={<Plus className="h-6 w-6" />} label="Create" />
           </UpsertActivityDialog>
           <UserDropdownMenu>

--- a/src/components/category-picker.tsx
+++ b/src/components/category-picker.tsx
@@ -42,7 +42,7 @@ const GENERIC_ERROR_CONFIG: Parameters<typeof _toast>[0] = {
 };
 
 type CategoryPickerProps = {
-  categories: Category[];
+  categories: Pick<Category, "id" | "name">[];
   selectedIds: string[];
   onChange: (ids: string[]) => void;
   mode?: "manage" | "filter";
@@ -64,7 +64,7 @@ export function CategoryPicker({
   const [search, setSearch] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
-  const [deleteTarget, setDeleteTarget] = useState<Category | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Pick<Category, "id" | "name"> | null>(null);
 
   const editInputRef = useRef<HTMLInputElement>(null);
   // guards rename-blur ↔ Pencil-click race
@@ -148,7 +148,7 @@ export function CategoryPicker({
     });
   };
 
-  const handleDelete = (category: Category) => {
+  const handleDelete = (category: Pick<Category, "id" | "name">) => {
     if (isPending) return;
     startTransition(async () => {
       try {

--- a/src/components/category-picker.tsx
+++ b/src/components/category-picker.tsx
@@ -45,6 +45,8 @@ type CategoryPickerProps = {
   categories: Pick<Category, "id" | "name">[];
   selectedIds: string[];
   onChange: (ids: string[]) => void;
+  onCategoryCreated?: (cat: Pick<Category, "id" | "name">) => void;
+  onPendingChange?: (pending: boolean) => void;
   mode?: "manage" | "filter";
   trigger?: React.ReactNode;
 };
@@ -53,6 +55,8 @@ export function CategoryPicker({
   categories,
   selectedIds,
   onChange,
+  onCategoryCreated,
+  onPendingChange,
   mode = "manage",
   trigger,
 }: CategoryPickerProps) {
@@ -100,6 +104,7 @@ export function CategoryPicker({
             description: `"${name}" has been created.`,
           });
           onChange([...selectedIds, result.data.id]);
+          onCategoryCreated?.({ id: result.data.id, name: result.data.name });
           setSearch("");
           router.refresh();
         } else {
@@ -179,6 +184,10 @@ export function CategoryPicker({
   useEffect(() => {
     if (editingId !== null) editInputRef.current?.focus();
   }, [editingId]);
+
+  useEffect(() => {
+    onPendingChange?.(isPending);
+  }, [isPending, onPendingChange]);
 
   return (
     <>

--- a/src/components/category-picker.tsx
+++ b/src/components/category-picker.tsx
@@ -212,7 +212,7 @@ export function CategoryPicker({
             </Button>
           )}
         </PopoverTrigger>
-        <PopoverContent className="p-0 w-[300px]" align="start">
+        <PopoverContent className="p-0 w-[var(--radix-popover-trigger-width)]" align="start">
           <Command shouldFilter={false}>
             <CommandInput
               value={search}
@@ -285,11 +285,12 @@ export function CategoryPicker({
                     <>
                       <span className="flex-1 truncate">{category.name}</span>
                       {mode !== "filter" && (
-                        <span className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100 [@media(hover:none)_and_(pointer:coarse)]:opacity-100">
+                        <span className="ml-auto flex items-center gap-2 opacity-0 group-hover:opacity-100 [@media(hover:none)_and_(pointer:coarse)]:opacity-100">
                           <button
                             type="button"
                             tabIndex={-1}
                             aria-label={`Rename ${category.name}`}
+                            className="rounded p-1.5 hover:bg-foreground/10 hover:text-foreground transition-colors"
                             onPointerDown={(e) => {
                               e.stopPropagation();
                               nextEditingIdRef.current = category.id;
@@ -301,19 +302,20 @@ export function CategoryPicker({
                               nextEditingIdRef.current = null;
                             }}
                           >
-                            <Pencil className="h-3 w-3" />
+                            <Pencil className="h-3.5 w-3.5" />
                           </button>
                           <button
                             type="button"
                             tabIndex={-1}
                             aria-label={`Delete ${category.name}`}
+                            className="rounded p-1.5 hover:bg-foreground/10 hover:text-foreground transition-colors"
                             onPointerDown={(e) => e.stopPropagation()}
                             onClick={(e) => {
                               e.stopPropagation();
                               setDeleteTarget(category);
                             }}
                           >
-                            <Trash2 className="h-3 w-3" />
+                            <Trash2 className="h-3.5 w-3.5" />
                           </button>
                         </span>
                       )}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,9 +1,71 @@
 "use client";
 
 import * as React from "react";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
-import { type ThemeProviderProps } from "next-themes";
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+type ThemeMode = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
+
+const STORAGE_KEY = "theme-mode";
+const COOKIE_KEY = "theme";
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+
+const ThemeContext = React.createContext<{
+  setTheme: (mode: ThemeMode) => void;
+} | null>(null);
+
+function getSystemTheme(): ResolvedTheme {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  const root = document.documentElement;
+  root.classList.remove("light", "dark");
+  root.classList.add(resolved);
+  root.style.colorScheme = resolved;
+  document.cookie = `${COOKIE_KEY}=${resolved}; path=/; max-age=${ONE_YEAR_SECONDS}; SameSite=Lax`;
+}
+
+function readMode(): ThemeMode {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === "light" || stored === "dark" || stored === "system"
+    ? stored
+    : "system";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = React.useState<ThemeMode>("system");
+
+  React.useEffect(() => {
+    const intent = readMode();
+    setMode(intent);
+    applyTheme(intent === "system" ? getSystemTheme() : intent);
+  }, []);
+
+  React.useEffect(() => {
+    if (mode !== "system") return;
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyTheme(mql.matches ? "dark" : "light");
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [mode]);
+
+  const setTheme = React.useCallback((next: ThemeMode) => {
+    setMode(next);
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next === "system" ? getSystemTheme() : next);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = React.useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Moon, Sun, Laptop } from "lucide-react";
-import { useTheme } from "next-themes";
+import { useTheme } from "@/components/theme-provider";
 
 import {
   DropdownMenuItem,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 flex flex-col w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/upsert-activity-dialog.tsx
+++ b/src/components/upsert-activity-dialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { Activity } from "@prisma/client";
+import type { ActivityWithCategories, CategoryOption } from "@/types";
 import {
   Dialog,
   DialogContent,
@@ -12,12 +12,14 @@ import { UpsertActivityForm } from "@/components/upsert-activity-form";
 
 type UpsertActivityDialogProps = {
   children: React.ReactNode;
-  activity?: Activity;
+  activity?: ActivityWithCategories;
+  categories: CategoryOption[];
 };
 
 export function UpsertActivityDialog({
   children,
   activity,
+  categories,
 }: UpsertActivityDialogProps) {
   const [open, setOpen] = useState(false);
 
@@ -37,6 +39,7 @@ export function UpsertActivityDialog({
         </DialogHeader>
         <UpsertActivityForm
           activity={activity}
+          categories={categories}
           onSuccess={() => setOpen(false)}
         />
       </DialogContent>

--- a/src/components/upsert-activity-dialog.tsx
+++ b/src/components/upsert-activity-dialog.tsx
@@ -26,7 +26,7 @@ export function UpsertActivityDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="sm:max-w-[425px] max-w-[90%] w-full">
+      <DialogContent className="sm:max-w-[425px] max-w-[90%] w-full flex flex-col overflow-hidden max-h-[90vh]">
         <DialogHeader>
           <DialogTitle>
             {activity ? "Update" : "Create New"} Activity

--- a/src/components/upsert-activity-form.tsx
+++ b/src/components/upsert-activity-form.tsx
@@ -21,8 +21,11 @@ import {
   Loader2Icon,
   PlusCircleIcon,
   Pencil,
+  X,
+  ChevronDown,
 } from "lucide-react";
-import { useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { useState, useTransition } from "react";
 import { createActivityAction } from "@/app/actions/create-activity-action";
 import { updateActivityAction } from "@/app/actions/update-activity-action";
 import { setFormErrors } from "@/lib/utils/form";
@@ -48,7 +51,20 @@ export function UpsertActivityForm({
   onSuccess,
 }: UpsertActivityFormProps) {
   const [isPending, startTransition] = useTransition();
+  const [optimisticCategories, setOptimisticCategories] = useState<CategoryOption[]>([]);
+  const [isCategoryPending, setIsCategoryPending] = useState(false);
   const router = useRouter();
+
+  const augmentedCategories: CategoryOption[] = [
+    ...categories,
+    ...optimisticCategories.filter(
+      (opt) => !categories.some((c) => c.id === opt.id)
+    ),
+  ];
+
+  const handleCategoryCreated = (cat: CategoryOption) => {
+    setOptimisticCategories((prev) => [...prev, cat]);
+  };
 
   const form = useForm<FormData>({
     resolver: zodResolver(
@@ -102,7 +118,7 @@ export function UpsertActivityForm({
   };
 
   return (
-    <div className="max-w-2xl mx-auto p-6 bg-background">
+    <div className="max-w-2xl mx-auto p-6 bg-background flex-1 min-h-0 overflow-y-auto">
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
           <FormField
@@ -140,22 +156,63 @@ export function UpsertActivityForm({
               <FormItem>
                 <FormLabel>Categories</FormLabel>
                 <CategoryPicker
-                  categories={categories}
+                  categories={augmentedCategories}
                   selectedIds={field.value}
                   onChange={field.onChange}
+                  onCategoryCreated={handleCategoryCreated}
+                  onPendingChange={setIsCategoryPending}
                   trigger={
                     <FormControl>
-                      <Button variant="outline" type="button" className="w-full justify-start font-normal">
-                        {field.value.length > 0
-                          ? `${field.value.length} selected`
-                          : "Select categories"}
-                      </Button>
+                      <div
+                        role="button"
+                        tabIndex={0}
+                        aria-label="Select categories"
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            (e.currentTarget as HTMLDivElement).click();
+                          }
+                        }}
+                        className="flex w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors md:text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 flex-wrap items-center gap-1.5 min-h-9 cursor-pointer"
+                      >
+                        {field.value.length === 0 ? (
+                          <span className="text-muted-foreground">
+                            Select categories
+                          </span>
+                        ) : (
+                          field.value.map((id: string) => {
+                            const cat = augmentedCategories.find((c) => c.id === id);
+                            if (!cat) return null;
+                            return (
+                              <Badge
+                                key={id}
+                                variant="secondary"
+                                className="font-normal pl-2 pr-0 py-0 [&:has(button:hover)]:bg-secondary"
+                              >
+                                <span>{cat.name}</span>
+                                <button
+                                  type="button"
+                                  aria-label={`Remove ${cat.name}`}
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    field.onChange(
+                                      field.value.filter((v: string) => v !== id)
+                                    );
+                                  }}
+                                  className="relative inline-flex items-center justify-center rounded-sm ml-1 mr-1 hover:bg-secondary-foreground/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring before:absolute before:inset-[-15px] before:content-['']"
+                                >
+                                  <X className="h-3.5 w-3.5" />
+                                </button>
+                              </Badge>
+                            );
+                          })
+                        )}
+                        <ChevronDown className="ml-auto h-4 w-4 opacity-50 shrink-0 self-center" />
+                      </div>
                     </FormControl>
                   }
                 />
-                <FormDescription>
-                  Tag this activity with categories.
-                </FormDescription>
+                <FormDescription>Tag this activity with categories.</FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -193,7 +250,7 @@ export function UpsertActivityForm({
             <Button
               type="submit"
               className="w-full text-base font-semibold"
-              disabled={isPending}
+              disabled={isCategoryPending || isPending}
             >
               {isPending ? (
                 <Loader2Icon className="h-4 w-4 animate-spin mr-2" />

--- a/src/components/upsert-activity-form.tsx
+++ b/src/components/upsert-activity-form.tsx
@@ -191,7 +191,7 @@ export function UpsertActivityForm({
                               <Badge
                                 key={id}
                                 variant="secondary"
-                                className="font-normal pl-2 pr-0 py-0 [&:has(button:hover)]:bg-secondary"
+                                className="font-normal text-sm pl-2 pr-0 py-0.5 [&:has(button:hover)]:bg-secondary"
                               >
                                 <span>{cat.name}</span>
                                 <button
@@ -207,7 +207,7 @@ export function UpsertActivityForm({
                                   }}
                                   className="relative inline-flex items-center justify-center rounded-sm ml-1 mr-1 hover:bg-secondary-foreground/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring before:absolute before:inset-[-15px] before:content-['']"
                                 >
-                                  <X className="h-3.5 w-3.5" />
+                                  <X className="h-4 w-4" />
                                 </button>
                               </Badge>
                             );

--- a/src/components/upsert-activity-form.tsx
+++ b/src/components/upsert-activity-form.tsx
@@ -1,5 +1,6 @@
 import { useForm } from "react-hook-form";
-import type { Activity } from "@prisma/client";
+import type { ActivityWithCategories, CategoryOption } from "@/types";
+import { CategoryPicker } from "@/components/category-picker";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createActivitySchema } from "@/app/schemas/create-activity-schema";
 import { updateActivitySchema } from "@/app/schemas/update-activity-schema";
@@ -32,15 +33,18 @@ type FormData = {
   activityId?: string;
   name: string;
   description: string;
+  categoryIds: string[];
 };
 
 type UpsertActivityFormProps = {
-  activity?: Activity;
+  activity?: ActivityWithCategories;
+  categories: CategoryOption[];
   onSuccess: () => void;
 };
 
 export function UpsertActivityForm({
   activity,
+  categories,
   onSuccess,
 }: UpsertActivityFormProps) {
   const [isPending, startTransition] = useTransition();
@@ -54,6 +58,7 @@ export function UpsertActivityForm({
       ...(activity && { activityId: activity.id }),
       name: activity?.name || "",
       description: activity?.description || "",
+      categoryIds: activity?.categories?.map((ac) => ac.categoryId) ?? [],
     },
   });
 
@@ -63,6 +68,7 @@ export function UpsertActivityForm({
         const formData = new FormData();
         formData.append("name", data.name);
         formData.append("description", data.description);
+        data.categoryIds.forEach((id) => formData.append("categoryIds", id));
         if (activity) {
           formData.append("activityId", activity.id);
         }
@@ -122,6 +128,33 @@ export function UpsertActivityForm({
                 </FormControl>
                 <FormDescription>
                   Choose a clear and concise name for your activity.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="categoryIds"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Categories</FormLabel>
+                <CategoryPicker
+                  categories={categories}
+                  selectedIds={field.value}
+                  onChange={field.onChange}
+                  trigger={
+                    <FormControl>
+                      <Button variant="outline" type="button" className="w-full justify-start font-normal">
+                        {field.value.length > 0
+                          ? `${field.value.length} selected`
+                          : "Select categories"}
+                      </Button>
+                    </FormControl>
+                  }
+                />
+                <FormDescription>
+                  Tag this activity with categories.
                 </FormDescription>
                 <FormMessage />
               </FormItem>

--- a/src/components/upsert-activity-form.tsx
+++ b/src/components/upsert-activity-form.tsx
@@ -17,7 +17,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
-  ActivityIcon,
   Loader2Icon,
   PlusCircleIcon,
   Pencil,
@@ -51,14 +50,16 @@ export function UpsertActivityForm({
   onSuccess,
 }: UpsertActivityFormProps) {
   const [isPending, startTransition] = useTransition();
-  const [optimisticCategories, setOptimisticCategories] = useState<CategoryOption[]>([]);
+  const [optimisticCategories, setOptimisticCategories] = useState<
+    CategoryOption[]
+  >([]);
   const [isCategoryPending, setIsCategoryPending] = useState(false);
   const router = useRouter();
 
   const augmentedCategories: CategoryOption[] = [
     ...categories,
     ...optimisticCategories.filter(
-      (opt) => !categories.some((c) => c.id === opt.id)
+      (opt) => !categories.some((c) => c.id === opt.id),
     ),
   ];
 
@@ -68,7 +69,7 @@ export function UpsertActivityForm({
 
   const form = useForm<FormData>({
     resolver: zodResolver(
-      activity ? updateActivitySchema : createActivitySchema
+      activity ? updateActivitySchema : createActivitySchema,
     ),
     defaultValues: {
       ...(activity && { activityId: activity.id }),
@@ -107,7 +108,7 @@ export function UpsertActivityForm({
       } catch (error) {
         console.error(
           `Activity ${activity ? "update" : "create"} error:`,
-          error
+          error,
         );
         form.setError("root", {
           type: "manual",
@@ -118,7 +119,7 @@ export function UpsertActivityForm({
   };
 
   return (
-    <div className="max-w-2xl mx-auto p-6 bg-background flex-1 min-h-0 overflow-y-auto">
+    <div className="max-w-2xl py-6 px-2 bg-background flex-1 min-h-0 overflow-y-auto">
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
           <FormField
@@ -128,9 +129,8 @@ export function UpsertActivityForm({
               <FormItem>
                 <FormLabel
                   htmlFor="activity-name"
-                  className="text-lg font-semibold flex items-center"
+                  className="text-lg font-semibold"
                 >
-                  <ActivityIcon className="w-5 h-5 mr-2" />
                   Name
                 </FormLabel>
                 <FormControl>
@@ -154,7 +154,9 @@ export function UpsertActivityForm({
             name="categoryIds"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Categories</FormLabel>
+                <FormLabel className="text-lg font-semibold">
+                  Categories
+                </FormLabel>
                 <CategoryPicker
                   categories={augmentedCategories}
                   selectedIds={field.value}
@@ -181,7 +183,9 @@ export function UpsertActivityForm({
                           </span>
                         ) : (
                           field.value.map((id: string) => {
-                            const cat = augmentedCategories.find((c) => c.id === id);
+                            const cat = augmentedCategories.find(
+                              (c) => c.id === id,
+                            );
                             if (!cat) return null;
                             return (
                               <Badge
@@ -196,7 +200,9 @@ export function UpsertActivityForm({
                                   onClick={(e) => {
                                     e.stopPropagation();
                                     field.onChange(
-                                      field.value.filter((v: string) => v !== id)
+                                      field.value.filter(
+                                        (v: string) => v !== id,
+                                      ),
                                     );
                                   }}
                                   className="relative inline-flex items-center justify-center rounded-sm ml-1 mr-1 hover:bg-secondary-foreground/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring before:absolute before:inset-[-15px] before:content-['']"
@@ -212,7 +218,9 @@ export function UpsertActivityForm({
                     </FormControl>
                   }
                 />
-                <FormDescription>Tag this activity with categories.</FormDescription>
+                <FormDescription>
+                  Choose relevant categories for your activity.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -238,8 +246,7 @@ export function UpsertActivityForm({
                   />
                 </FormControl>
                 <FormDescription>
-                  Provide additional details about your activity (max 500
-                  characters).
+                  Provide additional details about your activity.
                 </FormDescription>
                 <FormMessage />
               </FormItem>

--- a/src/lib/services/get-activities.ts
+++ b/src/lib/services/get-activities.ts
@@ -87,6 +87,7 @@ export async function getActivities({
           include: {
             category: true,
           },
+          orderBy: { createdAt: "asc" },
         },
       },
       skip,

--- a/src/lib/services/get-activity.ts
+++ b/src/lib/services/get-activity.ts
@@ -42,6 +42,7 @@ export async function getActivity({
           include: {
             category: true,
           },
+          orderBy: { createdAt: "asc" },
         },
       },
     });

--- a/src/lib/services/get-bookmarked-activities.ts
+++ b/src/lib/services/get-bookmarked-activities.ts
@@ -42,6 +42,7 @@ export async function getBookmarkedActivities({
         include: {
           category: true,
         },
+        orderBy: { createdAt: "asc" },
       },
     },
   });

--- a/src/lib/services/get-categories.ts
+++ b/src/lib/services/get-categories.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { prisma } from "@/lib/prisma";
 import { TeamMembershipRole } from "@prisma/client";
 import type { Category } from "@prisma/client";
@@ -6,29 +7,31 @@ type GetCategoriesParams = {
   userId: string;
 };
 
-export async function getCategories({
-  userId,
-}: GetCategoriesParams): Promise<Category[]> {
-  try {
-    return prisma.category.findMany({
-      where: {
-        userId,
-        team: {
-          teamMemberships: {
-            some: {
-              userId,
-              role: TeamMembershipRole.OWNER,
+export const getCategories = cache(
+  async ({
+    userId,
+  }: GetCategoriesParams): Promise<Category[]> => {
+    try {
+      return prisma.category.findMany({
+        where: {
+          userId,
+          team: {
+            teamMemberships: {
+              some: {
+                userId,
+                role: TeamMembershipRole.OWNER,
+              },
             },
           },
         },
-      },
-      orderBy: {
-        name: "asc",
-        createdAt: "desc",
-      },
-    });
-  } catch (error) {
-    console.error("Error fetching categories:", error);
-    throw error;
+        orderBy: {
+          name: "asc",
+          createdAt: "desc",
+        },
+      });
+    } catch (error) {
+      console.error("Error fetching categories:", error);
+      throw error;
+    }
   }
-}
+);

--- a/src/lib/services/get-categories.ts
+++ b/src/lib/services/get-categories.ts
@@ -1,7 +1,7 @@
 import { cache } from "react";
 import { prisma } from "@/lib/prisma";
 import { TeamMembershipRole } from "@prisma/client";
-import type { Category } from "@prisma/client";
+import type { CategoryOption } from "@/types";
 
 type GetCategoriesParams = {
   userId: string;
@@ -10,7 +10,7 @@ type GetCategoriesParams = {
 export const getCategories = cache(
   async ({
     userId,
-  }: GetCategoriesParams): Promise<Category[]> => {
+  }: GetCategoriesParams): Promise<CategoryOption[]> => {
     try {
       return prisma.category.findMany({
         where: {
@@ -27,6 +27,10 @@ export const getCategories = cache(
         orderBy: {
           name: "asc",
           createdAt: "desc",
+        },
+        select: {
+          id: true,
+          name: true,
         },
       });
     } catch (error) {

--- a/src/lib/services/get-categories.ts
+++ b/src/lib/services/get-categories.ts
@@ -24,10 +24,10 @@ export const getCategories = cache(
             },
           },
         },
-        orderBy: {
-          name: "asc",
-          createdAt: "desc",
-        },
+        orderBy: [
+          { name: "asc" },
+          { createdAt: "desc" },
+        ],
         select: {
           id: true,
           name: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@prisma/client";
+import type { Prisma, Category } from "@prisma/client";
 import type { FieldErrors } from "react-hook-form";
 
 export type ActivityWithTasksAndTimeEntries = Prisma.ActivityGetPayload<{
@@ -25,6 +25,8 @@ export type ActivityWithCategories = Prisma.ActivityGetPayload<{
     };
   };
 }>;
+
+export type CategoryOption = Pick<Category, "id" | "name">;
 
 export type TaskWithTimeEntries = Prisma.TaskGetPayload<{
   include: {


### PR DESCRIPTION
Closes #407

Surface CategoryPicker as a Categories field in UpsertActivityForm above description, and prefetch the category list server-side from each of the three entry points (bottom-nav, dashboard cards, activity detail). Wraps getCategories in React cache() to dedupe per-render calls and projects to { id, name }[] at every RSC->client boundary.