### PR TITLE
feat(categories): display category badges on activity cards and header

### DIFF
--- a/src/app/dashboard/activities/[id]/components/activity-header.tsx
+++ b/src/app/dashboard/activities/[id]/components/activity-header.tsx
@@ -7,6 +7,7 @@ import { ActivityIcon, ChevronLeft } from "lucide-react";
 import { ActivityActions } from "@/app/dashboard/components/activity-actions";
 import { BookmarkButton } from "@/components/bookmark-button";
 import type { ActivityWithTasksAndTimeEntries, CategoryOption } from "@/types";
+import { Badge } from "@/components/ui/badge";
 
 type ActivityHeaderProps = {
   activity: ActivityWithTasksAndTimeEntries;
@@ -43,6 +44,15 @@ export function ActivityHeader({ activity, categories }: ActivityHeaderProps) {
             <p className="mt-1 text-sm sm:text-base md:text-lg text-muted-foreground line-clamp-2">
               {activity.description}
             </p>
+          )}
+          {activity.categories.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {activity.categories.map((ac) => (
+                <Badge key={ac.id} variant="secondary" title={ac.category.name}>
+                  {ac.category.name}
+                </Badge>
+              ))}
+            </div>
           )}
         </div>
         <div className="flex items-center sm:self-center ml-auto sm:ml-0">

--- a/src/app/dashboard/activities/[id]/components/activity-header.tsx
+++ b/src/app/dashboard/activities/[id]/components/activity-header.tsx
@@ -7,7 +7,7 @@ import { ActivityIcon, ChevronLeft } from "lucide-react";
 import { ActivityActions } from "@/app/dashboard/components/activity-actions";
 import { BookmarkButton } from "@/components/bookmark-button";
 import type { ActivityWithTasksAndTimeEntries, CategoryOption } from "@/types";
-import { Badge } from "@/components/ui/badge";
+import { CategoryBadge } from "@/components/category-badge";
 
 type ActivityHeaderProps = {
   activity: ActivityWithTasksAndTimeEntries;
@@ -48,9 +48,9 @@ export function ActivityHeader({ activity, categories }: ActivityHeaderProps) {
           {activity.categories.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-2">
               {activity.categories.map((ac) => (
-                <Badge key={ac.id} variant="secondary" title={ac.category.name}>
+                <CategoryBadge key={ac.id} title={ac.category.name}>
                   {ac.category.name}
-                </Badge>
+                </CategoryBadge>
               ))}
             </div>
           )}

--- a/src/app/dashboard/components/activity-card.tsx
+++ b/src/app/dashboard/components/activity-card.tsx
@@ -27,7 +27,7 @@ import {
 import { isActivityRunning } from "@/lib/utils/is-activity-running";
 import { useGetActivityRemainingTime } from "@/hooks/use-get-activity-remaining-time";
 import { useReturnUrl } from "@/hooks/use-return-url";
-import { Badge } from "@/components/ui/badge";
+import { CategoryBadge } from "@/components/category-badge";
 
 type ActivityCardProps = {
   activity: ActivityWithTasksAndTimeEntries;
@@ -79,17 +79,16 @@ export function ActivityCard({
           {activity.categories.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-2">
               {activity.categories.slice(0, 2).map((ac) => (
-                <Badge key={ac.id} variant="secondary" title={ac.category.name}>
+                <CategoryBadge key={ac.id} title={ac.category.name}>
                   {ac.category.name}
-                </Badge>
+                </CategoryBadge>
               ))}
               {activity.categories.length > 2 && (
-                <Badge
-                  variant="secondary"
+                <CategoryBadge
                   title={`${activity.categories.length - 2} more categories`}
                 >
                   +{activity.categories.length - 2} more
-                </Badge>
+                </CategoryBadge>
               )}
             </div>
           )}

--- a/src/app/dashboard/components/activity-card.tsx
+++ b/src/app/dashboard/components/activity-card.tsx
@@ -27,6 +27,7 @@ import {
 import { isActivityRunning } from "@/lib/utils/is-activity-running";
 import { useGetActivityRemainingTime } from "@/hooks/use-get-activity-remaining-time";
 import { useReturnUrl } from "@/hooks/use-return-url";
+import { Badge } from "@/components/ui/badge";
 
 type ActivityCardProps = {
   activity: ActivityWithTasksAndTimeEntries;
@@ -74,6 +75,23 @@ export function ActivityCard({
             <CardDescription className="text-sm text-muted-foreground mt-1 truncate min-h-[1.5rem]">
               {activity.description}
             </CardDescription>
+          )}
+          {activity.categories.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {activity.categories.slice(0, 2).map((ac) => (
+                <Badge key={ac.id} variant="secondary" title={ac.category.name}>
+                  {ac.category.name}
+                </Badge>
+              ))}
+              {activity.categories.length > 2 && (
+                <Badge
+                  variant="secondary"
+                  title={`${activity.categories.length - 2} more categories`}
+                >
+                  +{activity.categories.length - 2} more
+                </Badge>
+              )}
+            </div>
           )}
         </CardHeader>
         <CardContent className="pb-2">

--- a/src/components/category-badge.tsx
+++ b/src/components/category-badge.tsx
@@ -1,0 +1,14 @@
+import { Badge } from "@/components/ui/badge";
+
+type CategoryBadgeProps = {
+  children: React.ReactNode;
+  title?: string;
+};
+
+export function CategoryBadge({ children, title }: CategoryBadgeProps) {
+  return (
+    <Badge variant="secondary" title={title}>
+      {children}
+    </Badge>
+  );
+}

--- a/src/lib/services/get-activities.ts
+++ b/src/lib/services/get-activities.ts
@@ -84,10 +84,8 @@ export async function getActivities({
           },
         },
         categories: {
-          include: {
-            category: true,
-          },
-          orderBy: { createdAt: "asc" },
+          orderBy: { category: { name: "asc" } },
+          include: { category: true },
         },
       },
       skip,

--- a/src/lib/services/get-activity.ts
+++ b/src/lib/services/get-activity.ts
@@ -39,10 +39,8 @@ export async function getActivity({
           },
         },
         categories: {
-          include: {
-            category: true,
-          },
-          orderBy: { createdAt: "asc" },
+          orderBy: { category: { name: "asc" } },
+          include: { category: true },
         },
       },
     });

--- a/src/lib/services/get-bookmarked-activities.ts
+++ b/src/lib/services/get-bookmarked-activities.ts
@@ -39,10 +39,8 @@ export async function getBookmarkedActivities({
         },
       },
       categories: {
-        include: {
-          category: true,
-        },
-        orderBy: { createdAt: "asc" },
+        orderBy: { category: { name: "asc" } },
+        include: { category: true },
       },
     },
   });


### PR DESCRIPTION
Render category badges on activity cards (truncated to 2 + overflow) and on the activity header. Sort included categories alphabetically by name in service reads for stable display order.

Closes #408