### PR TITLE
feat(tasks): add duration preset picker to task form

### DIFF
--- a/src/components/duration-preset-picker.tsx
+++ b/src/components/duration-preset-picker.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { MS_PER_MIN } from "@/lib/utils/time";
+import { cn } from "@/lib/utils";
+
+const DEFAULT_PRESETS_MINUTES = [5, 10, 15, 20, 30] as const;
+
+type DurationPresetPickerProps = {
+  value: number;
+  onChange: (ms: number) => void;
+  minMs?: number;
+  presetsMinutes?: readonly number[];
+  className?: string;
+};
+
+export function DurationPresetPicker({
+  value,
+  onChange,
+  minMs,
+  presetsMinutes = DEFAULT_PRESETS_MINUTES,
+  className,
+}: DurationPresetPickerProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Duration presets"
+      className={cn("flex flex-wrap gap-1.5", className)}
+    >
+      {presetsMinutes.map((minutes) => {
+        const presetMs = minutes * MS_PER_MIN;
+        const isSelected = value === presetMs;
+        const isDisabled = minMs !== undefined && presetMs < minMs;
+
+        const chip = (
+          <Button
+            key={minutes}
+            type="button"
+            variant={isSelected ? "default" : "outline"}
+            size="sm"
+            aria-pressed={isSelected}
+            aria-label={`${minutes} minutes`}
+            aria-disabled={isDisabled || undefined}
+            className={cn(
+              "transition-transform duration-75 active:scale-95",
+              isDisabled && "opacity-50 cursor-not-allowed"
+            )}
+            onClick={() => {
+              if (isDisabled) return;
+              onChange(presetMs);
+            }}
+          >
+            {minutes}m
+          </Button>
+        );
+
+        if (!isDisabled) return chip;
+
+        return (
+          <Tooltip key={minutes}>
+            <TooltipTrigger asChild>
+              <span>{chip}</span>
+            </TooltipTrigger>
+            <TooltipContent>Less than elapsed time</TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/duration-preset-picker.tsx
+++ b/src/components/duration-preset-picker.tsx
@@ -10,7 +10,7 @@ const DEFAULT_PRESETS_MINUTES = [5, 10, 15, 20, 30] as const;
 type DurationPresetPickerProps = {
   value: number;
   onChange: (ms: number) => void;
-  minMs?: number;
+  elapsedMs?: number;
   presetsMinutes?: readonly number[];
   className?: string;
 };
@@ -18,7 +18,7 @@ type DurationPresetPickerProps = {
 export function DurationPresetPicker({
   value,
   onChange,
-  minMs,
+  elapsedMs,
   presetsMinutes = DEFAULT_PRESETS_MINUTES,
   className,
 }: DurationPresetPickerProps) {
@@ -31,7 +31,7 @@ export function DurationPresetPicker({
       {presetsMinutes.map((minutes) => {
         const presetMs = minutes * MS_PER_MIN;
         const isSelected = value === presetMs;
-        const isDisabled = minMs !== undefined && presetMs < minMs;
+        const isDisabled = elapsedMs !== undefined && presetMs < elapsedMs;
 
         const chip = (
           <Button

--- a/src/components/upsert-task-form.tsx
+++ b/src/components/upsert-task-form.tsx
@@ -25,6 +25,7 @@ import { setFormErrors } from "@/lib/utils/form";
 import { useRouter } from "next/navigation";
 import type { CreateTaskSchema } from "@/app/schemas/create-task-schema";
 import { DurationInput } from "@/components/duration-input";
+import { DurationPresetPicker } from "@/components/duration-preset-picker";
 import { RootFormError } from "@/components/root-form-error";
 import { getUpdateTaskSchema } from "@/app/schemas/update-task-schema";
 import { formatTimeMMss, getTaskElapsedTime } from "@/lib/utils/time";
@@ -149,6 +150,11 @@ export function UpsertTaskForm({
                     <ClockIcon className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
                   </div>
                 </FormControl>
+                <DurationPresetPicker
+                  value={field.value}
+                  onChange={field.onChange}
+                  minMs={task ? elapsedMs : undefined}
+                />
                 {task && elapsedMs > 0 ? (
                   <FormDescription>
                     Current elapsed time {formatTimeMMss(elapsedMs)}

--- a/src/components/upsert-task-form.tsx
+++ b/src/components/upsert-task-form.tsx
@@ -153,7 +153,7 @@ export function UpsertTaskForm({
                 <DurationPresetPicker
                   value={field.value}
                   onChange={field.onChange}
-                  minMs={task ? elapsedMs : undefined}
+                  elapsedMs={task ? elapsedMs : undefined}
                 />
                 {task && elapsedMs > 0 ? (
                   <FormDescription>


### PR DESCRIPTION
Add a row of preset chips (5/10/15/20/30 min) below the duration input on the task create/edit form so users can pick common durations in one click. Manual typing remains available. In edit mode, presets below the task's elapsed time are aria-disabled with a tooltip explaining why.

Closes #444