### PR TITLE
fix(tasks): prevent Create Task button from stretching on mobile

### DIFF
--- a/src/app/dashboard/activities/[id]/components/tasks-list.tsx
+++ b/src/app/dashboard/activities/[id]/components/tasks-list.tsx
@@ -53,7 +53,7 @@ type TasksListProps = {
 function CreateTaskControl({ activityId }: { activityId: string }) {
   return (
     <UpsertTaskDialog activityId={activityId}>
-      <Button variant="outline" className="w-full sm:w-auto">
+      <Button variant="outline">
         <PlusCircleIcon className="mr-2 h-4 w-4" />
         Create Task
       </Button>


### PR DESCRIPTION
The button used w-full sm:w-auto, forcing full width below the sm breakpoint and cramping the Tasks title in its header row. Drop the width classes so it sizes to its content at all breakpoints.