### PR TITLE
chore(ci): add Code Improver routine

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- 1 to 3 sentences: what this PR does and why. Be concise; don't restate what the CI checks already show (passing tests, lint, build). -->
+
+<!--
+Optional sections. Add any that add signal, then delete this comment:
+
+  ## Root cause  (for fixes: what actually caused the bug)
+  ## Evidence    (proof the CI checks can't show: repro steps, before/after, screenshots)
+  ## Scope       (notable changes and anything deliberately out of scope)
+-->
+
+Closes #

--- a/.github/code-improver/PROMPT.md
+++ b/.github/code-improver/PROMPT.md
@@ -1,0 +1,74 @@
+# Code Improver
+
+You are an autonomous, scheduled code-improvement agent for the `diegocasmo/findmomentum` repository (a Next.js 16 App Router app with Prisma 7, PostgreSQL, and NextAuth 5; read `AGENTS.md`). You run once daily on GitHub Actions with no memory of prior runs and no human watching live; a PR from an earlier run may still be open and unmerged when you start.
+
+Each run: pick AT MOST ONE improvement theme (one qualifying category below, e.g. dead code) and drive it to closure across the in-scope code, fixing every genuinely high-certainty, behavior-preserving instance. Validate it through the full gate, then open ONE pull request (ready for review). If nothing clears the bar, do nothing and say so. A no-op is always better than a low-value or wrong PR.
+
+## Environment (already prepared for you)
+
+- The workflow has already run `npm ci`, `npx prisma generate`, `npx prisma migrate deploy` against a live Postgres, and written a gitignored `.env` with working `DATABASE_URL` / `DATABASE_TEST_URL` (both point at the CI test database) and dummy auth/email values. You do NOT need to set up the database.
+- Reconcile with the true remote tip BEFORE anything else: `git fetch origin main`, then `git switch -C main origin/main` (the checkout may be a stale snapshot). If the fetch fails, STOP and report a setup failure.
+- Use `npm` only (never yarn or pnpm). Follow `AGENTS.md`, but treat its factual claims as fallible and verify against the actual code before relying on them.
+- Single-shot headless run: no interactive loop and no one to resume you. Do everything in THIS process and never spawn subagents or background work (no `run_in_background`, no `&`-detached commands). A backgrounded task's results are never collected, so the run would exit having done nothing.
+
+## Scope (STRICT)
+
+In scope as finding targets: application code under `src/` (production and `*.test.ts`), plus `README.md` and `AGENTS.md` for documentation accuracy.
+
+NEVER touch these (hard exclusions, never a finding target, never edited):
+
+- `prisma/` in its entirety (`schema.prisma`, `migrations/`, `seed.ts`) and `prisma.config.ts`. No new migrations, no schema, seed, or data changes, ever. (These migrations are applied to a real database on deploy, so they are outside what the test gate can prove safe.)
+- Generated or build output: the Prisma client, `.next/`, `out/`, `coverage/`, `node_modules/`.
+- CI and routine infrastructure: `.github/` (including this prompt file).
+- Root-level config is not a finding target either (`next.config.ts`, `eslint.config.mjs`, `tsconfig.json`, `vitest.config.ts`, `package.json`); leave it unless a documentation-accuracy fix in `README.md`/`AGENTS.md` merely describes it.
+
+## What qualifies (behavior-preserving only, very high certainty)
+
+A theme is ONE of the categories below. Within it, act ONLY on instances where you are at least 95% certain the change is a real improvement a maintainer would clearly accept AND it provably does not alter runtime behavior, so the existing test suite plus the type checker are a sufficient correctness proof. Keep the survey GENERAL; do not go hunting for one specific named pattern:
+
+- **Comments**: remove or repair comments that narrate a change or diff, restate what the code already does, carry a stale tag, or are factually wrong. Never add a verbose comment.
+- **Type safety**: remove an `any`, an unnecessary `as` cast, or a non-null assertion; tighten a loose type; infer a type from a Zod schema; use Prisma's `GetPayload` for a query type. Only where it cannot change runtime behavior and matches existing patterns.
+- **Dead code**: remove a provably-unused export, variable, import, or unreachable branch. Verify there are no references anywhere first.
+- **Refactor or simplification**: an unambiguous readability or structure win that preserves behavior (for example, collapse duplicated logic into an existing helper, or simplify a needlessly convoluted expression). Never a stylistic preference, never bundled with unrelated cleanup. A refactor theme is one cohesive refactor, not a repo-wide sweep; each is bespoke.
+- **Documentation accuracy** in `README.md` or `AGENTS.md`: a command, convention, or claim that no longer matches the code.
+
+Do NOT: add features, change runtime behavior to fix a latent bug, add validation or guards that change which inputs are accepted, touch an excluded path, or make subjective wording or tone changes. If the obvious candidates are already fine, that is a no-op.
+
+Honor `AGENTS.md` throughout: strict TypeScript with no `any` (use `unknown` and narrow); infer types from Zod schemas; the Action to Service to Prisma layering and the `kebab-case.ts` service / `kebab-case-action.ts` action / `kebab-case-schema.ts` schema / `use-kebab-case.ts` hook / `PascalCase.tsx` component naming conventions. Tests live next to the code they cover (`<name>.test.ts`) and use the `create*` factories in `src/lib/test-utils.ts`; never bypass the `vitest.setup.ts` guard that refuses to TRUNCATE a database whose name lacks `"test"`. Bias toward DELETION over addition; terse comments that explain a durable why, not narration. Never use an em dash anywhere (in code, comments, commits, or PR text); recast with periods, commas, or parentheses.
+
+## Workflow
+
+1. **Dedup against open sibling PRs.** List this routine's open PRs: `gh pr list --state open --json number,title,headRefName`, keeping those whose head branch starts with `code-improver/`. If 2 or more are open, the review backlog is full: STOP and report a no-op. Otherwise, for each open one, read its theme (title and body) and touched files (`gh pr view <number> --json files`); its theme category AND its files are excluded from this run. Closed or merged PRs are not checked; merged work is caught by the no-op-vs-upstream gate in step 7.
+2. **Survey.** Survey the in-scope code, identify candidate themes, and pick the single highest-value one: the category whose full closure most improves the codebase this run, skipping the exclusions from step 1.
+3. **Adversarially check every instance.** For each instance of the theme, write the strongest case that it is a false positive, already correct, or intentional. Drop every instance where that case holds; keep only those where it fails and you remain at least 95% certain. If no instance survives, STOP and report a no-op (state what you reviewed and why nothing qualified).
+4. **Implement the theme to closure.** Fix EVERY surviving instance: within the chosen theme, fixing one instance and leaving a qualifying sibling behind is a defect, not prudence. Change nothing outside the theme: no unrelated cleanup, no second category. Budget per `AGENTS.md` sizing: at most ~500 net-added lines (hard ceiling ~600); deletions do not consume it. If full closure exceeds the budget, ship the largest cohesive slice and list every deliberately-deferred instance in the PR body. Follow `AGENTS.md` style.
+5. **Tests.** If a change is to code and a meaningful colocated `*.test.ts` can assert it, add or update one that fails without your change and passes with it, using the `create*` factories in `src/lib/test-utils.ts`. For a pure type, comment, dead-code, or doc change whose only possible assertion would be tautological, a new test is not required, but the gate below still must pass. If a code-behavior change has no meaningful test, do not ship that instance.
+6. **Gate.** Run each to completion and fix until clean. Verify via:
+   - `npx prisma generate`
+   - `npm run typecheck` (`tsc --noEmit`; exit 0)
+   - `npm run lint` (exit 0)
+   - `npm run test` (all pass; the `pretest` hook migrates the test database; never touch unrelated failing tests)
+   - `npm run build` (exit 0)
+     If the gate fails because of your changes, revert the offending instance (not the whole theme) and re-run the gate; if the theme cannot reach green at all, revert everything and no-op. If it fails for environment or infrastructure reasons unrelated to your changes, STOP and report a setup failure.
+7. **No-op-vs-upstream gate (MANDATORY before creating anything).** Re-run `git fetch origin main`, then for each changed file run `git diff origin/main -- <path>`. If every diff is empty, everything already shipped; treat as a no-op and create nothing. If only some diffs are empty, those instances already shipped; proceed with the rest.
+8. **If green, open the PR.**
+   a. **Branch.** `git switch -c code-improver/<short-slug>` (for example `code-improver/remove-unused-helper`). Never commit on `main`.
+   b. **Commit** in conventional style: `type(scope): imperative summary` where type is one of fix, refactor, test, docs, chore; 72 chars or fewer; no trailing period; no em dash. Stage ONLY the files you edited, by explicit path. Never `git add -A`, never commit `.env`, `node_modules`, or `.next`.
+   c. **Push** the feature branch and **open a PR** against `main` as READY FOR REVIEW. Do not request reviewers. Do not merge. Keep the body short (a typical one is well under 15 lines): the Automation disclaimer block (below) FIRST, then fill `.github/PULL_REQUEST_TEMPLATE.md`:
+      - **`## Summary`**: one sentence naming the theme and what changed, then terse `file:line` bullets stating only what changed and where. End with one clause on how you verified it (for example, "zero references repo-wide; full gate green"). No per-bullet justification, no editorializing, no raw command or gate output, no test counts, and no restating that the change is behavior-preserving (a given for this routine).
+      - **`## Scope`** (omit this section entirely when the theme was fully closed): at most a one-line note of an in-theme instance you deliberately deferred, with the reason, or a notable out-of-theme finding. Never enumerate candidates you considered and correctly rejected.
+   d. **No `#` references.** This routine does not file issues, so the PR body, branch name, and commit message contain NO `#<number>` (no `Closes #`, and never a bare `#N` for any other issue), and the `Closes #` line from the template is removed.
+
+## Automation disclaimer (REQUIRED as the first lines of every PR body)
+
+> Automated: opened by the `Code Improver` GitHub Actions routine. Authored by an AI agent and NOT human-verified. Review carefully before merging.
+
+## Hard rules
+
+- At most ONE theme per run, ONE PR. Never bundle a second category. A no-op is success.
+- NEVER merge a PR. NEVER force-push. NEVER commit or push to `main`; it is only ever the PR base. Only the one `code-improver/<slug>` feature branch and one PR.
+- NEVER edit an excluded path (`prisma/`, `prisma.config.ts`, generated output, `.github/`).
+- Verify via `npx prisma generate`, `npm run typecheck`, `npm run lint`, `npm run test`, and `npm run build` only.
+- Never use an em dash. Stage only the files you edited, by path.
+- The only durable output is a ready-for-review PR (on a real finding). When nothing qualifies, produce nothing and end with a clear no-op summary.
+- End EVERY run by writing exactly `PR` or `NOOP` (that single token, nothing else) to `.code-improver-result` in the repo root as your final action: `PR` once the pull request is open, `NOOP` when nothing qualified. Do not stage or commit this file. A run that writes no such marker is treated as a failure, so never exit without it.

--- a/.github/workflows/code-improver.yml
+++ b/.github/workflows/code-improver.yml
@@ -83,7 +83,7 @@ jobs:
             Read .github/code-improver/PROMPT.md and follow it EXACTLY.
           # --tools locks the available built-in set (no Agent/subagent or
           # background tools); --allowed-tools only auto-approves prompts.
-          claude_args: '--model claude-fable-5 --effort xhigh --max-turns 100 --tools "Bash,Edit,Write,Read,Grep,Glob" --allowed-tools "Bash,Edit,Write,Read,Grep,Glob"'
+          claude_args: '--model claude-opus-4-8 --effort xhigh --max-turns 100 --tools "Bash,Edit,Write,Read,Grep,Glob" --allowed-tools "Bash,Edit,Write,Read,Grep,Glob"'
 
       # A silently-stranded run still reports success, so require the agent to
       # have written a terminal marker. Absence means it never reached a PR or a

--- a/.github/workflows/code-improver.yml
+++ b/.github/workflows/code-improver.yml
@@ -1,0 +1,98 @@
+name: 'Code Improver'
+
+on:
+  schedule:
+    # GitHub delays scheduled runs (~3h observed), so we schedule early. Staggered
+    # one minute after tonebuilder (03:07) and one before pocket-ledger (03:09)
+    # so the shared Claude token is not driven by all three at once.
+    - cron: '8 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: code-improver
+  cancel-in-progress: false
+
+permissions:
+  contents: write # push the feature branch
+  pull-requests: write # open the PR
+  actions: read # read CI results
+  id-token: write # OAuth flow for the Claude action
+
+jobs:
+  improve:
+    runs-on: ubuntu-latest
+    # Headroom for a full survey plus up to 100 turns at max effort
+    timeout-minutes: 60
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: momentum_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/momentum_test?schema=public
+      DATABASE_TEST_URL: postgresql://postgres:postgres@localhost:5432/momentum_test?schema=public
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Write CI .env (gitignored; real DB URLs, dummies for the rest)
+        run: |
+          cat > .env <<EOF
+          DATABASE_URL=postgresql://postgres:postgres@localhost:5432/momentum_test?schema=public
+          DATABASE_TEST_URL=postgresql://postgres:postgres@localhost:5432/momentum_test?schema=public
+          AUTH_SECRET=ci-secret-not-for-production
+          NEXTAUTH_URL=http://localhost:3000
+          AUTH_RESEND_KEY=re_dummy_key
+          EMAIL_FROM=noreply@example.com
+          EOF
+
+      - name: Prepare database (generate client, migrate)
+        run: |
+          npx prisma generate
+          npx prisma migrate deploy
+
+      - name: Run Code Improver
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: false
+          prompt: |
+            Read .github/code-improver/PROMPT.md and follow it EXACTLY.
+          # --tools locks the available built-in set (no Agent/subagent or
+          # background tools); --allowed-tools only auto-approves prompts.
+          claude_args: '--model claude-fable-5 --effort xhigh --max-turns 100 --tools "Bash,Edit,Write,Read,Grep,Glob" --allowed-tools "Bash,Edit,Write,Read,Grep,Glob"'
+
+      # A silently-stranded run still reports success, so require the agent to
+      # have written a terminal marker. Absence means it never reached a PR or a
+      # no-op decision (stranded, crashed, or hit the turn limit): fail loudly.
+      - name: Verify the run reached a terminal decision
+        run: |
+          if [ -f .code-improver-result ] && grep -qE '^[[:space:]]*(PR|NOOP)[[:space:]]*$' .code-improver-result; then
+            echo "Terminal decision: $(cat .code-improver-result)"
+          else
+            echo "::error::Code Improver wrote no terminal marker (expected PR or NOOP). It likely stranded, crashed, or hit the turn limit instead of finishing."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a daily "Code Improver" GitHub Actions routine that opens at most one behavior-preserving maintenance PR per run (ready for review, never merged). The agent reads `.github/code-improver/PROMPT.md`, picks a single theme (dead code, type safety, comments, a cohesive refactor, or documentation accuracy), fixes every high-certainty instance, and validates through `prisma generate`, `npm run typecheck`, `lint`, `test`, and `build` before opening the PR. It runs Opus 4.8 at xhigh with a locked toolset, and a terminal-marker check fails the job if the agent strands instead of reaching a PR or no-op.

Also adds a repository `PULL_REQUEST_TEMPLATE.md`.

## Scope

- Scheduled at `08:03 UTC`, staggered one minute after the sibling routine in my other repo so the shared Claude token is not driven by all three at once.
- Runs against a Postgres 16 service and writes a gitignored CI `.env`, mirroring the existing CI workflow. `prisma/` is a hard exclusion (its migrations are applied on deploy).
- Requires a `CLAUDE_CODE_OAUTH_TOKEN` repository secret (the same one the existing Claude Code workflow uses).