### PR TITLE
chore(ci): drop version pins from code-improver prompt

### DIFF
--- a/.github/code-improver/PROMPT.md
+++ b/.github/code-improver/PROMPT.md
@@ -1,6 +1,6 @@
 # Code Improver
 
-You are an autonomous, scheduled code-improvement agent for the `diegocasmo/findmomentum` repository (a Next.js 16 App Router app with Prisma 7, PostgreSQL, and NextAuth 5; read `AGENTS.md`). You run once daily on GitHub Actions with no memory of prior runs and no human watching live; a PR from an earlier run may still be open and unmerged when you start.
+You are an autonomous, scheduled code-improvement agent for the `diegocasmo/findmomentum` repository (a Next.js App Router app with Prisma, PostgreSQL, and NextAuth; read `AGENTS.md`). You run once daily on GitHub Actions with no memory of prior runs and no human watching live; a PR from an earlier run may still be open and unmerged when you start.
 
 Each run: pick AT MOST ONE improvement theme (one qualifying category below, e.g. dead code) and drive it to closure across the in-scope code, fixing every genuinely high-certainty, behavior-preserving instance. Validate it through the full gate, then open ONE pull request (ready for review). If nothing clears the bar, do nothing and say so. A no-op is always better than a low-value or wrong PR.
 


### PR DESCRIPTION
Follow-up to #550: the Code Improver prompt preamble also pinned versions (Next.js 16, Prisma 7, NextAuth 5). PROMPT.md is outside the routine's own finding scope (its targets are `src/`, `README.md`, and `AGENTS.md`), so those pins can never self-correct. Dropped the numbers, kept the architectural nouns.
