### PR TITLE
chore(ci): run Code Improver every other day

### DIFF
--- a/.github/workflows/code-improver.yml
+++ b/.github/workflows/code-improver.yml
@@ -2,10 +2,11 @@ name: 'Code Improver'
 
 on:
   schedule:
-    # GitHub delays scheduled runs (~3h observed), so we schedule early. Staggered
-    # one minute after tonebuilder (03:07) and one before pocket-ledger (03:09)
-    # so the shared Claude token is not driven by all three at once.
-    - cron: '8 3 * * *'
+    # Every other day. GitHub delays scheduled runs (~3h observed), so we schedule
+    # early. The odd minute offset keeps this from starting alongside the other
+    # routines that share the same Claude token. Day-of-month stepping restarts at
+    # the 1st, so a 31-day month is followed by two runs on consecutive days.
+    - cron: '8 3 */2 * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Step the cron day-of-month by 2 (`8 3 */2 * *`) so the routine runs on odd days instead of daily. Halves automated PR volume while keeping the maintenance pass frequent enough to stay useful.

## Scope

Day-of-month stepping restarts at the 1st, so the real cadence is 186 runs a year rather than 182.5: 179 gaps of exactly 2 days, and 7 consecutive-day pairs where a 31-day month rolls into the next 1st (plus Feb 29 in leap years). Noted in a comment on the cron line. A perfect 48h period would need a daily job gated on epoch-day parity, which is more moving parts than those 7 days are worth.